### PR TITLE
Some small improvements

### DIFF
--- a/contracts/token/ShareBridgeToken.sol
+++ b/contracts/token/ShareBridgeToken.sol
@@ -61,6 +61,8 @@ contract ShareBridgeToken is Initializable, IVotable, BridgeToken {
 
   uint256 public constant VERSION = 2;
   
+  string public terms;
+
   uint256 public totalShares = 0; // total number of shares, maybe not all tokenized
   address public override votingSession;
   string public boardResolutionDocumentUrl;
@@ -95,6 +97,10 @@ contract ShareBridgeToken is Initializable, IVotable, BridgeToken {
     );
     tokenizedSharePercentage = _tokenizedSharePercentage;
     emit TokenizedSharePercentageSet(_tokenizedSharePercentage);
+  }
+
+  function setTerms(string memory _terms) public onlyAdministrator {
+    terms = _terms;
   }
 
   /**

--- a/contracts/token/ShareBridgeToken.sol
+++ b/contracts/token/ShareBridgeToken.sol
@@ -50,13 +50,6 @@ import "../interfaces/IVotable.sol";
 
 
 contract ShareBridgeToken is Initializable, IVotable, BridgeToken {
-  /**
-  * Purpose:
-  * This event is emitted when the percentage of shares that are tokenized is changed
-  *
-  * @param tokenizedSharePercentage - new percentage of shares that are tokenized
-  */
-  event TokenizedSharePercentageSet(uint16 tokenizedSharePercentage);
 
   /**
   * Purpose:
@@ -68,7 +61,7 @@ contract ShareBridgeToken is Initializable, IVotable, BridgeToken {
 
   uint256 public constant VERSION = 2;
   
-  uint16 public tokenizedSharePercentage;
+  uint256 public totalShares = 0; // total number of shares, maybe not all tokenized
   address public override votingSession;
   string public boardResolutionDocumentUrl;
   bytes32 public boardResolutionDocumentHash;
@@ -105,12 +98,14 @@ contract ShareBridgeToken is Initializable, IVotable, BridgeToken {
   }
 
   /**
-  * @dev Set the percentage of shares that are tokenized
-  * @param _tokenizedSharePercentage the percentage of shares that are tokenized
-  */
-  function setTokenizedSharePercentage(uint16 _tokenizedSharePercentage) public onlyAdministrator {
-    tokenizedSharePercentage = _tokenizedSharePercentage;
-    emit TokenizedSharePercentageSet(_tokenizedSharePercentage);
+   * Declares the number of total shares, including those that have not been tokenized and those
+   * that are held by the company itself. This number can be substiantially higher than totalSupply()
+   * in case not all shares have been tokenized. Also, it can be lower than totalSupply() in case some
+   * tokens have become invalid.
+   */
+  function setTotalShares(uint256 _newTotalShares) public onlyAdministrator {
+    require(_newTotalShares >= totalSupply(), "below supply");
+    totalShares = _newTotalShares;
   }
 
   /**

--- a/contracts/token/abstract/BridgeERC20.sol
+++ b/contracts/token/abstract/BridgeERC20.sol
@@ -241,6 +241,15 @@ contract BridgeERC20 is Initializable, OwnableUpgradeSafe, IAdministrable, IGove
     return true;
   }
 
+  // ERC-677 functionality, can be useful for swapping and wrapping tokens
+  function transferAndCall(address recipient, uint amount, bytes calldata data) public returns (bool) {
+    bool success = transfer(recipient, amount);
+    if (success){
+      success = IERC677Receiver(recipient).onTokenTransfer(msg.sender, amount, data);
+    }
+    return success;
+  }
+
   /**
   * @dev Gets the balance of the specified address.
   * @param _owner The address to query the the balance of.
@@ -421,4 +430,10 @@ contract BridgeERC20 is Initializable, OwnableUpgradeSafe, IAdministrable, IGove
 
   /* Reserved slots for future use: https://docs.openzeppelin.com/sdk/2.5/writing-contracts.html#modifying-your-contracts */
   uint256[50] private ______gap;
+}
+
+interface IERC677Receiver {
+    
+    function onTokenTransfer(address from, uint256 amount, bytes calldata data) external returns (bool);
+
 }


### PR DESCRIPTION
I propose three small changes:
1. Add a field to link to the terms of share tokens (maybe the same should be done for bond tokens)
2. Signal the total number of shares instead of the tokenized percentage for better accuracy and fewer transactions
3. Support for ERC-677

More detailed reasoning for each change can be found in the commits.

Warning: this code is not tested. I don't even know if it compiles. :) But it works fine with our token (https://github.com/aktionariat/contracts/blob/master/src/Shares.sol).